### PR TITLE
fix: use dot notation for schema property keys (Anthropic API compat)

### DIFF
--- a/src/tools/create-subscription-price.ts
+++ b/src/tools/create-subscription-price.ts
@@ -22,7 +22,7 @@ export const schema = {
     .string()
     .optional()
     .describe(
-      "Territory ID (e.g. USA). When the price point came from list-subscription-price-points with filter[territory], pass that same territory here. Required by API for territory-specific price points; omit only if applying to all."
+      "Territory ID (e.g. USA). When the price point came from list-subscription-price-points with filter.territory, pass that same territory here. Required by API for territory-specific price points; omit only if applying to all."
     ),
   startDate: z
     .string()
@@ -41,7 +41,7 @@ export const schema = {
 export const metadata: ToolMetadata = {
   name: "create-subscription-price",
   description:
-    "Attach a price to a subscription (by price point and optionally territory). Set subscription availability first with create-subscription-availability for the territory, or you may get 409 ENTITY_ERROR.RELATIONSHIP.INVALID. Use price point IDs from list-subscription-price-points; when you used filter[territory] there, pass that same territoryId here.",
+    "Attach a price to a subscription (by price point and optionally territory). Set subscription availability first with create-subscription-availability for the territory, or you may get 409 ENTITY_ERROR.RELATIONSHIP.INVALID. Use price point IDs from list-subscription-price-points; when you used filter.territory there, pass that same territoryId here.",
   annotations: {
     title: "Create subscription price",
     readOnlyHint: false,

--- a/src/tools/list-actors.ts
+++ b/src/tools/list-actors.ts
@@ -9,7 +9,7 @@ import { unwrapApiResult } from "../lib/api-error.ts";
 import { toArray } from "../lib/query.ts";
 
 export const schema = {
-  "filter[id]": z
+  "filter.id": z
     .union([z.string(), z.array(z.string())])
     .describe("Actor ID(s) to fetch (required). Get IDs from submission/version responses."),
   limit: z.number().min(1).max(200).default(50).optional(),
@@ -30,7 +30,7 @@ export const metadata: ToolMetadata = {
 
 export default async function listActorsTool(args: InferSchema<typeof schema>) {
   const client = getClient();
-  const ids = toArray(args["filter[id]"]);
+  const ids = toArray(args["filter.id"]);
   if (!ids?.length) throw new Error("At least one filter[id] is required");
   const query: NonNullable<ActorsGetCollectionData["query"]> = {
     "filter[id]": ids,

--- a/src/tools/list-app-categories.ts
+++ b/src/tools/list-app-categories.ts
@@ -19,11 +19,11 @@ export const schema = {
     .describe(
       "Maximum number of app categories to return (default 100, max 200)"
     ),
-  "filter[platforms]": z
+  "filter.platforms": z
     .union([platformEnum, z.array(platformEnum)])
     .optional()
     .describe("Filter by platform(s)"),
-  "exists[parent]": z
+  "exists.parent": z
     .boolean()
     .optional()
     .describe(
@@ -48,11 +48,11 @@ export default async function listAppCategoriesTool(
   const client = getClient();
   const query: NonNullable<AppCategoriesGetCollectionData["query"]> = {
     limit: args.limit,
-    ...(toArray(args["filter[platforms]"])?.length && {
-      "filter[platforms]": toArray(args["filter[platforms]"])!,
+    ...(toArray(args["filter.platforms"])?.length && {
+      "filter[platforms]": toArray(args["filter.platforms"])!,
     }),
-    ...(args["exists[parent]"] !== undefined && {
-      "exists[parent]": args["exists[parent]"],
+    ...(args["exists.parent"] !== undefined && {
+      "exists[parent]": args["exists.parent"],
     }),
   };
   const result =

--- a/src/tools/list-app-encryption-declarations.ts
+++ b/src/tools/list-app-encryption-declarations.ts
@@ -19,15 +19,15 @@ export const schema = {
     .describe(
       "Maximum number of app encryption declarations to return (default 100, max 200)"
     ),
-  "filter[app]": z
+  "filter.app": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by app ID(s)"),
-  "filter[builds]": z
+  "filter.builds": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by build ID(s)"),
-  "filter[platform]": z
+  "filter.platform": z
     .union([platformEnum, z.array(platformEnum)])
     .optional()
     .describe("Filter by platform(s)"),
@@ -52,14 +52,14 @@ export default async function listAppEncryptionDeclarationsTool(
   const query: NonNullable<AppEncryptionDeclarationsGetCollectionData["query"]> =
     {
       limit: args.limit,
-      ...(toArray(args["filter[app]"])?.length && {
-        "filter[app]": toArray(args["filter[app]"])!,
+      ...(toArray(args["filter.app"])?.length && {
+        "filter[app]": toArray(args["filter.app"])!,
       }),
-      ...(toArray(args["filter[builds]"])?.length && {
-        "filter[builds]": toArray(args["filter[builds]"])!,
+      ...(toArray(args["filter.builds"])?.length && {
+        "filter[builds]": toArray(args["filter.builds"])!,
       }),
-      ...(toArray(args["filter[platform]"])?.length && {
-        "filter[platform]": toArray(args["filter[platform]"])!,
+      ...(toArray(args["filter.platform"])?.length && {
+        "filter[platform]": toArray(args["filter.platform"])!,
       }),
     };
   const result =

--- a/src/tools/list-app-store-version-localizations.ts
+++ b/src/tools/list-app-store-version-localizations.ts
@@ -18,7 +18,7 @@ export const schema = {
     .describe(
       "Maximum number of localizations to return (default 100, max 200)"
     ),
-  "filter[locale]": z
+  "filter.locale": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by locale(s) (e.g. en-US)"),
@@ -47,8 +47,8 @@ export default async function listAppStoreVersionLocalizationsTool(
     path: { id: args.appStoreVersionId },
     query: {
       limit: args.limit,
-      ...(toArray(args["filter[locale]"])?.length && {
-        "filter[locale]": toArray(args["filter[locale]"])!,
+      ...(toArray(args["filter.locale"])?.length && {
+        "filter[locale]": toArray(args["filter.locale"])!,
       }),
     },
   };

--- a/src/tools/list-app-store-versions.ts
+++ b/src/tools/list-app-store-versions.ts
@@ -37,19 +37,19 @@ export const schema = {
     .max(200)
     .default(100)
     .describe("Maximum number of versions to return (default 100, max 200)"),
-  "filter[platform]": z
+  "filter.platform": z
     .union([platformEnum, z.array(platformEnum)])
     .optional()
     .describe("Filter by platform(s)"),
-  "filter[versionString]": z
+  "filter.versionString": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by version string(s)"),
-  "filter[appVersionState]": z
+  "filter.appVersionState": z
     .union([appVersionStateEnum, z.array(appVersionStateEnum)])
     .optional()
     .describe("Filter by app version state(s)"),
-  "filter[id]": z
+  "filter.id": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by version ID(s)"),
@@ -74,17 +74,17 @@ export default async function listAppStoreVersionsTool(
     AppsAppStoreVersionsGetToManyRelatedData["query"]
   > = {
     limit: args.limit,
-    ...(toArray(args["filter[platform]"])?.length && {
-      "filter[platform]": toArray(args["filter[platform]"])!,
+    ...(toArray(args["filter.platform"])?.length && {
+      "filter[platform]": toArray(args["filter.platform"])!,
     }),
-    ...(toArray(args["filter[versionString]"])?.length && {
-      "filter[versionString]": toArray(args["filter[versionString]"])!,
+    ...(toArray(args["filter.versionString"])?.length && {
+      "filter[versionString]": toArray(args["filter.versionString"])!,
     }),
-    ...(toArray(args["filter[appVersionState]"])?.length && {
-      "filter[appVersionState]": toArray(args["filter[appVersionState]"])!,
+    ...(toArray(args["filter.appVersionState"])?.length && {
+      "filter[appVersionState]": toArray(args["filter.appVersionState"])!,
     }),
-    ...(toArray(args["filter[id]"])?.length && {
-      "filter[id]": toArray(args["filter[id]"])!,
+    ...(toArray(args["filter.id"])?.length && {
+      "filter[id]": toArray(args["filter.id"])!,
     }),
   };
   const result =

--- a/src/tools/list-apps.ts
+++ b/src/tools/list-apps.ts
@@ -15,19 +15,19 @@ export const schema = {
     .max(200)
     .default(100)
     .describe("Maximum number of apps to return (default 100, max 200)"),
-  "filter[bundleId]": z
+  "filter.bundleId": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by bundle identifier(s)"),
-  "filter[name]": z
+  "filter.name": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by app name(s)"),
-  "filter[sku]": z
+  "filter.sku": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by SKU(s)"),
-  "filter[id]": z
+  "filter.id": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by app ID(s)"),
@@ -49,17 +49,17 @@ export default async function listAppsTool(args: InferSchema<typeof schema>) {
   const client = getClient();
   const query: NonNullable<AppsGetCollectionData["query"]> = {
     limit: args.limit,
-    ...(toArray(args["filter[bundleId]"])?.length && {
-      "filter[bundleId]": toArray(args["filter[bundleId]"])!,
+    ...(toArray(args["filter.bundleId"])?.length && {
+      "filter[bundleId]": toArray(args["filter.bundleId"])!,
     }),
-    ...(toArray(args["filter[name]"])?.length && {
-      "filter[name]": toArray(args["filter[name]"])!,
+    ...(toArray(args["filter.name"])?.length && {
+      "filter[name]": toArray(args["filter.name"])!,
     }),
-    ...(toArray(args["filter[sku]"])?.length && {
-      "filter[sku]": toArray(args["filter[sku]"])!,
+    ...(toArray(args["filter.sku"])?.length && {
+      "filter[sku]": toArray(args["filter.sku"])!,
     }),
-    ...(toArray(args["filter[id]"])?.length && {
-      "filter[id]": toArray(args["filter[id]"])!,
+    ...(toArray(args["filter.id"])?.length && {
+      "filter[id]": toArray(args["filter.id"])!,
     }),
   };
   const result = await client.api.Apps.appsGetCollection({ query });

--- a/src/tools/list-beta-app-localizations.ts
+++ b/src/tools/list-beta-app-localizations.ts
@@ -17,15 +17,15 @@ export const schema = {
     .describe(
       "Maximum number of beta app localizations to return (default 100, max 200)"
     ),
-  "filter[app]": z
+  "filter.app": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by app ID(s)"),
-  "filter[locale]": z
+  "filter.locale": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by locale(s) (e.g. en-US)"),
-  "filter[id]": z
+  "filter.id": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by beta app localization ID(s)"),
@@ -49,14 +49,14 @@ export default async function listBetaAppLocalizationsTool(
   const client = getClient();
   const query: NonNullable<BetaAppLocalizationsGetCollectionData["query"]> = {
     limit: args.limit,
-    ...(toArray(args["filter[app]"])?.length && {
-      "filter[app]": toArray(args["filter[app]"])!,
+    ...(toArray(args["filter.app"])?.length && {
+      "filter[app]": toArray(args["filter.app"])!,
     }),
-    ...(toArray(args["filter[locale]"])?.length && {
-      "filter[locale]": toArray(args["filter[locale]"])!,
+    ...(toArray(args["filter.locale"])?.length && {
+      "filter[locale]": toArray(args["filter.locale"])!,
     }),
-    ...(toArray(args["filter[id]"])?.length && {
-      "filter[id]": toArray(args["filter[id]"])!,
+    ...(toArray(args["filter.id"])?.length && {
+      "filter[id]": toArray(args["filter.id"])!,
     }),
   };
   const result =

--- a/src/tools/list-beta-app-review-details.ts
+++ b/src/tools/list-beta-app-review-details.ts
@@ -9,7 +9,7 @@ import { unwrapApiResult } from "../lib/api-error.ts";
 import { toArray } from "../lib/query.ts";
 
 export const schema = {
-  "filter[app]": z
+  "filter.app": z
     .union([z.string(), z.array(z.string())])
     .describe("App ID(s) (required). Beta app review details for this app."),
   limit: z
@@ -20,7 +20,7 @@ export const schema = {
     .describe(
       "Maximum number of beta app review details to return (default 100, max 200)"
     ),
-  "filter[id]": z
+  "filter.id": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by beta app review detail ID(s)"),
@@ -43,10 +43,10 @@ export default async function listBetaAppReviewDetailsTool(
 ) {
   const client = getClient();
   const query: NonNullable<BetaAppReviewDetailsGetCollectionData["query"]> = {
-    "filter[app]": toArray(args["filter[app]"])!,
+    "filter[app]": toArray(args["filter.app"])!,
     limit: args.limit,
-    ...(toArray(args["filter[id]"])?.length && {
-      "filter[id]": toArray(args["filter[id]"])!,
+    ...(toArray(args["filter.id"])?.length && {
+      "filter[id]": toArray(args["filter.id"])!,
     }),
   };
   const result =

--- a/src/tools/list-beta-app-review-submissions.ts
+++ b/src/tools/list-beta-app-review-submissions.ts
@@ -16,7 +16,7 @@ const betaReviewStateEnum = z.enum([
 ]);
 
 export const schema = {
-  "filter[build]": z
+  "filter.build": z
     .union([z.string(), z.array(z.string())])
     .describe(
       "Build ID(s) (required). Beta app review submissions for this build."
@@ -29,7 +29,7 @@ export const schema = {
     .describe(
       "Maximum number of beta app review submissions to return (default 100, max 200)"
     ),
-  "filter[betaReviewState]": z
+  "filter.betaReviewState": z
     .union([betaReviewStateEnum, z.array(betaReviewStateEnum)])
     .optional()
     .describe("Filter by beta review state(s)"),
@@ -53,10 +53,10 @@ export default async function listBetaAppReviewSubmissionsTool(
   const client = getClient();
   const query: NonNullable<BetaAppReviewSubmissionsGetCollectionData["query"]> =
     {
-      "filter[build]": toArray(args["filter[build]"])!,
+      "filter[build]": toArray(args["filter.build"])!,
       limit: args.limit,
-      ...(toArray(args["filter[betaReviewState]"])?.length && {
-        "filter[betaReviewState]": toArray(args["filter[betaReviewState]"])!,
+      ...(toArray(args["filter.betaReviewState"])?.length && {
+        "filter[betaReviewState]": toArray(args["filter.betaReviewState"])!,
       }),
     };
   const result =

--- a/src/tools/list-beta-groups.ts
+++ b/src/tools/list-beta-groups.ts
@@ -15,15 +15,15 @@ export const schema = {
     .max(200)
     .default(100)
     .describe("Maximum number of groups to return (default 100, max 200)"),
-  "filter[app]": z
+  "filter.app": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by app ID(s)"),
-  "filter[name]": z
+  "filter.name": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by group name(s)"),
-  "filter[id]": z
+  "filter.id": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by beta group ID(s)"),
@@ -46,14 +46,14 @@ export default async function listBetaGroupsTool(
   const client = getClient();
   const query: NonNullable<BetaGroupsGetCollectionData["query"]> = {
     limit: args.limit,
-    ...(toArray(args["filter[app]"])?.length && {
-      "filter[app]": toArray(args["filter[app]"])!,
+    ...(toArray(args["filter.app"])?.length && {
+      "filter[app]": toArray(args["filter.app"])!,
     }),
-    ...(toArray(args["filter[name]"])?.length && {
-      "filter[name]": toArray(args["filter[name]"])!,
+    ...(toArray(args["filter.name"])?.length && {
+      "filter[name]": toArray(args["filter.name"])!,
     }),
-    ...(toArray(args["filter[id]"])?.length && {
-      "filter[id]": toArray(args["filter[id]"])!,
+    ...(toArray(args["filter.id"])?.length && {
+      "filter[id]": toArray(args["filter.id"])!,
     }),
   };
   const result = await client.api.BetaGroups.betaGroupsGetCollection({

--- a/src/tools/list-beta-license-agreements.ts
+++ b/src/tools/list-beta-license-agreements.ts
@@ -9,7 +9,7 @@ import { unwrapApiResult } from "../lib/api-error.ts";
 import { toArray } from "../lib/query.ts";
 
 export const schema = {
-  "filter[app]": z
+  "filter.app": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by app ID(s)"),
@@ -35,8 +35,8 @@ export default async function listBetaLicenseAgreementsTool(
   const client = getClient();
   const query: NonNullable<BetaLicenseAgreementsGetCollectionData["query"]> = {
     limit: args.limit ?? 50,
-    ...(toArray(args["filter[app]"])?.length && {
-      "filter[app]": toArray(args["filter[app]"])!,
+    ...(toArray(args["filter.app"])?.length && {
+      "filter[app]": toArray(args["filter.app"])!,
     }),
   };
   const result =

--- a/src/tools/list-beta-testers.ts
+++ b/src/tools/list-beta-testers.ts
@@ -15,27 +15,27 @@ export const schema = {
     .max(200)
     .default(100)
     .describe("Maximum number of beta testers to return (default 100, max 200)"),
-  "filter[apps]": z
+  "filter.apps": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by app ID(s)"),
-  "filter[betaGroups]": z
+  "filter.betaGroups": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by beta group ID(s)"),
-  "filter[email]": z
+  "filter.email": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by email(s)"),
-  "filter[firstName]": z
+  "filter.firstName": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by first name(s)"),
-  "filter[lastName]": z
+  "filter.lastName": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by last name(s)"),
-  "filter[id]": z
+  "filter.id": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by beta tester ID(s)"),
@@ -58,23 +58,23 @@ export default async function listBetaTestersTool(
   const client = getClient();
   const query: NonNullable<BetaTestersGetCollectionData["query"]> = {
     limit: args.limit,
-    ...(toArray(args["filter[apps]"])?.length && {
-      "filter[apps]": toArray(args["filter[apps]"])!,
+    ...(toArray(args["filter.apps"])?.length && {
+      "filter[apps]": toArray(args["filter.apps"])!,
     }),
-    ...(toArray(args["filter[betaGroups]"])?.length && {
-      "filter[betaGroups]": toArray(args["filter[betaGroups]"])!,
+    ...(toArray(args["filter.betaGroups"])?.length && {
+      "filter[betaGroups]": toArray(args["filter.betaGroups"])!,
     }),
-    ...(toArray(args["filter[email]"])?.length && {
-      "filter[email]": toArray(args["filter[email]"])!,
+    ...(toArray(args["filter.email"])?.length && {
+      "filter[email]": toArray(args["filter.email"])!,
     }),
-    ...(toArray(args["filter[firstName]"])?.length && {
-      "filter[firstName]": toArray(args["filter[firstName]"])!,
+    ...(toArray(args["filter.firstName"])?.length && {
+      "filter[firstName]": toArray(args["filter.firstName"])!,
     }),
-    ...(toArray(args["filter[lastName]"])?.length && {
-      "filter[lastName]": toArray(args["filter[lastName]"])!,
+    ...(toArray(args["filter.lastName"])?.length && {
+      "filter[lastName]": toArray(args["filter.lastName"])!,
     }),
-    ...(toArray(args["filter[id]"])?.length && {
-      "filter[id]": toArray(args["filter[id]"])!,
+    ...(toArray(args["filter.id"])?.length && {
+      "filter[id]": toArray(args["filter.id"])!,
     }),
   };
   const result = await client.api.BetaTesters.betaTestersGetCollection({

--- a/src/tools/list-build-beta-details.ts
+++ b/src/tools/list-build-beta-details.ts
@@ -17,11 +17,11 @@ export const schema = {
     .describe(
       "Maximum number of build beta details to return (default 100, max 200)"
     ),
-  "filter[build]": z
+  "filter.build": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by build ID(s)"),
-  "filter[id]": z
+  "filter.id": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by build beta detail ID(s)"),
@@ -45,11 +45,11 @@ export default async function listBuildBetaDetailsTool(
   const client = getClient();
   const query: NonNullable<BuildBetaDetailsGetCollectionData["query"]> = {
     limit: args.limit,
-    ...(toArray(args["filter[build]"])?.length && {
-      "filter[build]": toArray(args["filter[build]"])!,
+    ...(toArray(args["filter.build"])?.length && {
+      "filter[build]": toArray(args["filter.build"])!,
     }),
-    ...(toArray(args["filter[id]"])?.length && {
-      "filter[id]": toArray(args["filter[id]"])!,
+    ...(toArray(args["filter.id"])?.length && {
+      "filter[id]": toArray(args["filter.id"])!,
     }),
   };
   const result =

--- a/src/tools/list-builds.ts
+++ b/src/tools/list-builds.ts
@@ -17,7 +17,7 @@ const processingStateEnum = z.enum([
 const platformEnum = z.enum(["IOS", "MAC_OS", "TV_OS", "VISION_OS"]);
 
 export const schema = {
-  "filter[app]": z
+  "filter.app": z
     .union([z.string(), z.array(z.string())])
     .describe("Filter by app ID(s) (required)"),
   limit: z
@@ -26,23 +26,23 @@ export const schema = {
     .max(200)
     .default(50)
     .describe("Maximum number of builds to return (default 50, max 200)"),
-  "filter[preReleaseVersion]": z
+  "filter.preReleaseVersion": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by pre-release version ID(s)"),
-  "filter[version]": z
+  "filter.version": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by build version string(s)"),
-  "filter[processingState]": z
+  "filter.processingState": z
     .union([processingStateEnum, z.array(processingStateEnum)])
     .optional()
     .describe("Filter by processing state(s)"),
-  "filter[preReleaseVersion.platform]": z
+  "filter.preReleaseVersion.platform": z
     .union([platformEnum, z.array(platformEnum)])
     .optional()
     .describe("Filter by pre-release platform(s)"),
-  "filter[id]": z
+  "filter.id": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by build ID(s)"),
@@ -63,23 +63,23 @@ export default async function listBuildsTool(args: InferSchema<typeof schema>) {
   const client = getClient();
   const query: NonNullable<BuildsGetCollectionData["query"]> = {
     limit: args.limit,
-    "filter[app]": toArray(args["filter[app]"])!,
-    ...(toArray(args["filter[preReleaseVersion]"])?.length && {
-      "filter[preReleaseVersion]": toArray(args["filter[preReleaseVersion]"])!,
+    "filter[app]": toArray(args["filter.app"])!,
+    ...(toArray(args["filter.preReleaseVersion"])?.length && {
+      "filter[preReleaseVersion]": toArray(args["filter.preReleaseVersion"])!,
     }),
-    ...(toArray(args["filter[version]"])?.length && {
-      "filter[version]": toArray(args["filter[version]"])!,
+    ...(toArray(args["filter.version"])?.length && {
+      "filter[version]": toArray(args["filter.version"])!,
     }),
-    ...(toArray(args["filter[processingState]"])?.length && {
-      "filter[processingState]": toArray(args["filter[processingState]"])!,
+    ...(toArray(args["filter.processingState"])?.length && {
+      "filter[processingState]": toArray(args["filter.processingState"])!,
     }),
-    ...(toArray(args["filter[preReleaseVersion.platform]"])?.length && {
+    ...(toArray(args["filter.preReleaseVersion.platform"])?.length && {
       "filter[preReleaseVersion.platform]": toArray(
-        args["filter[preReleaseVersion.platform]"]
+        args["filter.preReleaseVersion.platform"]
       )!,
     }),
-    ...(toArray(args["filter[id]"])?.length && {
-      "filter[id]": toArray(args["filter[id]"])!,
+    ...(toArray(args["filter.id"])?.length && {
+      "filter[id]": toArray(args["filter.id"])!,
     }),
   };
   const result = await client.api.Builds.buildsGetCollection({ query });

--- a/src/tools/list-bundle-ids.ts
+++ b/src/tools/list-bundle-ids.ts
@@ -17,19 +17,19 @@ export const schema = {
     .max(200)
     .default(100)
     .describe("Maximum number of bundle IDs to return (default 100, max 200)"),
-  "filter[identifier]": z
+  "filter.identifier": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by bundle identifier(s)"),
-  "filter[platform]": z
+  "filter.platform": z
     .union([platformEnum, z.array(platformEnum)])
     .optional()
     .describe("Filter by platform(s)"),
-  "filter[name]": z
+  "filter.name": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by name(s)"),
-  "filter[id]": z
+  "filter.id": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by bundle ID(s)"),
@@ -52,17 +52,17 @@ export default async function listBundleIdsTool(
   const client = getClient();
   const query: NonNullable<BundleIdsGetCollectionData["query"]> = {
     limit: args.limit,
-    ...(toArray(args["filter[identifier]"])?.length && {
-      "filter[identifier]": toArray(args["filter[identifier]"])!,
+    ...(toArray(args["filter.identifier"])?.length && {
+      "filter[identifier]": toArray(args["filter.identifier"])!,
     }),
-    ...(toArray(args["filter[platform]"])?.length && {
-      "filter[platform]": toArray(args["filter[platform]"])!,
+    ...(toArray(args["filter.platform"])?.length && {
+      "filter[platform]": toArray(args["filter.platform"])!,
     }),
-    ...(toArray(args["filter[name]"])?.length && {
-      "filter[name]": toArray(args["filter[name]"])!,
+    ...(toArray(args["filter.name"])?.length && {
+      "filter[name]": toArray(args["filter.name"])!,
     }),
-    ...(toArray(args["filter[id]"])?.length && {
-      "filter[id]": toArray(args["filter[id]"])!,
+    ...(toArray(args["filter.id"])?.length && {
+      "filter[id]": toArray(args["filter.id"])!,
     }),
   };
   const result = await client.api.BundleIds.bundleIdsGetCollection({

--- a/src/tools/list-certificates.ts
+++ b/src/tools/list-certificates.ts
@@ -36,19 +36,19 @@ export const schema = {
     .max(200)
     .default(100)
     .describe("Maximum number of certificates to return (default 100, max 200)"),
-  "filter[certificateType]": z
+  "filter.certificateType": z
     .union([certificateTypeEnum, z.array(certificateTypeEnum)])
     .optional()
     .describe("Filter by certificate type(s)"),
-  "filter[serialNumber]": z
+  "filter.serialNumber": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by serial number(s)"),
-  "filter[displayName]": z
+  "filter.displayName": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by display name(s)"),
-  "filter[id]": z
+  "filter.id": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by certificate ID(s)"),
@@ -71,17 +71,17 @@ export default async function listCertificatesTool(
   const client = getClient();
   const query: NonNullable<CertificatesGetCollectionData["query"]> = {
     limit: args.limit,
-    ...(toArray(args["filter[certificateType]"])?.length && {
-      "filter[certificateType]": toArray(args["filter[certificateType]"])!,
+    ...(toArray(args["filter.certificateType"])?.length && {
+      "filter[certificateType]": toArray(args["filter.certificateType"])!,
     }),
-    ...(toArray(args["filter[serialNumber]"])?.length && {
-      "filter[serialNumber]": toArray(args["filter[serialNumber]"])!,
+    ...(toArray(args["filter.serialNumber"])?.length && {
+      "filter[serialNumber]": toArray(args["filter.serialNumber"])!,
     }),
-    ...(toArray(args["filter[displayName]"])?.length && {
-      "filter[displayName]": toArray(args["filter[displayName]"])!,
+    ...(toArray(args["filter.displayName"])?.length && {
+      "filter[displayName]": toArray(args["filter.displayName"])!,
     }),
-    ...(toArray(args["filter[id]"])?.length && {
-      "filter[id]": toArray(args["filter[id]"])!,
+    ...(toArray(args["filter.id"])?.length && {
+      "filter[id]": toArray(args["filter.id"])!,
     }),
   };
   const result = await client.api.Certificates.certificatesGetCollection({

--- a/src/tools/list-ci-products.ts
+++ b/src/tools/list-ci-products.ts
@@ -19,11 +19,11 @@ export const schema = {
     .describe(
       "Maximum number of CI products to return (default 100, max 200)"
     ),
-  "filter[app]": z
+  "filter.app": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by app ID(s)"),
-  "filter[productType]": z
+  "filter.productType": z
     .union([productTypeEnum, z.array(productTypeEnum)])
     .optional()
     .describe("Filter by product type(s)"),
@@ -46,11 +46,11 @@ export default async function listCiProductsTool(
   const client = getClient();
   const query: NonNullable<CiProductsGetCollectionData["query"]> = {
     limit: args.limit,
-    ...(toArray(args["filter[app]"])?.length && {
-      "filter[app]": toArray(args["filter[app]"])!,
+    ...(toArray(args["filter.app"])?.length && {
+      "filter[app]": toArray(args["filter.app"])!,
     }),
-    ...(toArray(args["filter[productType]"])?.length && {
-      "filter[productType]": toArray(args["filter[productType]"])!,
+    ...(toArray(args["filter.productType"])?.length && {
+      "filter[productType]": toArray(args["filter.productType"])!,
     }),
   };
   const result =

--- a/src/tools/list-customer-reviews.ts
+++ b/src/tools/list-customer-reviews.ts
@@ -26,11 +26,11 @@ export const schema = {
     .max(200)
     .default(50)
     .describe("Maximum number of reviews to return (default 50, max 200)"),
-  "filter[rating]": z
+  "filter.rating": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by rating(s), e.g. 1, 2, 3, 4, 5"),
-  "exists[publishedResponse]": z
+  "exists.publishedResponse": z
     .boolean()
     .optional()
     .describe("Filter by whether a developer response exists"),
@@ -61,13 +61,13 @@ export default async function listCustomerReviewsTool(
     AppStoreVersionsCustomerReviewsGetToManyRelatedData["query"]
   > = {
     limit: args.limit,
-    ...(args["filter[rating]"] !== undefined && {
-      "filter[rating]": Array.isArray(args["filter[rating]"])
-        ? args["filter[rating]"]
-        : [args["filter[rating]"]!],
+    ...(args["filter.rating"] !== undefined && {
+      "filter[rating]": Array.isArray(args["filter.rating"])
+        ? args["filter.rating"]
+        : [args["filter.rating"]!],
     }),
-    ...(args["exists[publishedResponse]"] !== undefined && {
-      "exists[publishedResponse]": args["exists[publishedResponse]"],
+    ...(args["exists.publishedResponse"] !== undefined && {
+      "exists[publishedResponse]": args["exists.publishedResponse"],
     }),
     ...(args.sort !== undefined && {
       sort: Array.isArray(args.sort) ? args.sort : [args.sort],

--- a/src/tools/list-devices.ts
+++ b/src/tools/list-devices.ts
@@ -18,23 +18,23 @@ export const schema = {
     .max(200)
     .default(100)
     .describe("Maximum number of devices to return (default 100, max 200)"),
-  "filter[platform]": z
+  "filter.platform": z
     .union([platformEnum, z.array(platformEnum)])
     .optional()
     .describe("Filter by platform(s)"),
-  "filter[status]": z
+  "filter.status": z
     .union([statusEnum, z.array(statusEnum)])
     .optional()
     .describe("Filter by device status(es)"),
-  "filter[name]": z
+  "filter.name": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by device name(s)"),
-  "filter[udid]": z
+  "filter.udid": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by UDID(s)"),
-  "filter[id]": z
+  "filter.id": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by device ID(s)"),
@@ -55,20 +55,20 @@ export default async function listDevicesTool(args: InferSchema<typeof schema>) 
   const client = getClient();
   const query: NonNullable<DevicesGetCollectionData["query"]> = {
     limit: args.limit,
-    ...(toArray(args["filter[platform]"])?.length && {
-      "filter[platform]": toArray(args["filter[platform]"])!,
+    ...(toArray(args["filter.platform"])?.length && {
+      "filter[platform]": toArray(args["filter.platform"])!,
     }),
-    ...(toArray(args["filter[status]"])?.length && {
-      "filter[status]": toArray(args["filter[status]"])!,
+    ...(toArray(args["filter.status"])?.length && {
+      "filter[status]": toArray(args["filter.status"])!,
     }),
-    ...(toArray(args["filter[name]"])?.length && {
-      "filter[name]": toArray(args["filter[name]"])!,
+    ...(toArray(args["filter.name"])?.length && {
+      "filter[name]": toArray(args["filter.name"])!,
     }),
-    ...(toArray(args["filter[udid]"])?.length && {
-      "filter[udid]": toArray(args["filter[udid]"])!,
+    ...(toArray(args["filter.udid"])?.length && {
+      "filter[udid]": toArray(args["filter.udid"])!,
     }),
-    ...(toArray(args["filter[id]"])?.length && {
-      "filter[id]": toArray(args["filter[id]"])!,
+    ...(toArray(args["filter.id"])?.length && {
+      "filter[id]": toArray(args["filter.id"])!,
     }),
   };
   const result = await client.api.Devices.devicesGetCollection({ query });

--- a/src/tools/list-nominations.ts
+++ b/src/tools/list-nominations.ts
@@ -12,7 +12,7 @@ const stateEnum = z.enum(["DRAFT", "SUBMITTED", "ARCHIVED"]);
 const typeEnum = z.enum(["APP_LAUNCH", "APP_ENHANCEMENTS", "NEW_CONTENT"]);
 
 export const schema = {
-  "filter[state]": z
+  "filter.state": z
     .union([stateEnum, z.array(stateEnum)])
     .describe("Filter by nomination state(s) (required)"),
   limit: z
@@ -23,11 +23,11 @@ export const schema = {
     .describe(
       "Maximum number of nominations to return (default 100, max 200)"
     ),
-  "filter[relatedApps]": z
+  "filter.relatedApps": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by related app ID(s)"),
-  "filter[type]": z
+  "filter.type": z
     .union([typeEnum, z.array(typeEnum)])
     .optional()
     .describe("Filter by nomination type(s)"),
@@ -50,13 +50,13 @@ export default async function listNominationsTool(
 ) {
   const client = getClient();
   const query: NonNullable<NominationsGetCollectionData["query"]> = {
-    "filter[state]": toArray(args["filter[state]"])!,
+    "filter[state]": toArray(args["filter.state"])!,
     limit: args.limit,
-    ...(toArray(args["filter[relatedApps]"])?.length && {
-      "filter[relatedApps]": toArray(args["filter[relatedApps]"])!,
+    ...(toArray(args["filter.relatedApps"])?.length && {
+      "filter[relatedApps]": toArray(args["filter.relatedApps"])!,
     }),
-    ...(toArray(args["filter[type]"])?.length && {
-      "filter[type]": toArray(args["filter[type]"])!,
+    ...(toArray(args["filter.type"])?.length && {
+      "filter[type]": toArray(args["filter.type"])!,
     }),
   };
   const result =

--- a/src/tools/list-pre-release-versions.ts
+++ b/src/tools/list-pre-release-versions.ts
@@ -19,19 +19,19 @@ export const schema = {
     .describe(
       "Maximum number of pre-release versions to return (default 100, max 200)"
     ),
-  "filter[app]": z
+  "filter.app": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by app ID(s)"),
-  "filter[platform]": z
+  "filter.platform": z
     .union([platformEnum, z.array(platformEnum)])
     .optional()
     .describe("Filter by platform(s)"),
-  "filter[version]": z
+  "filter.version": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by version string(s)"),
-  "filter[id]": z
+  "filter.id": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by pre-release version ID(s)"),
@@ -57,17 +57,17 @@ export default async function listPreReleaseVersionsTool(
     PreReleaseVersionsGetCollectionData["query"]
   > = {
     limit: args.limit,
-    ...(toArray(args["filter[app]"])?.length && {
-      "filter[app]": toArray(args["filter[app]"])!,
+    ...(toArray(args["filter.app"])?.length && {
+      "filter[app]": toArray(args["filter.app"])!,
     }),
-    ...(toArray(args["filter[platform]"])?.length && {
-      "filter[platform]": toArray(args["filter[platform]"])!,
+    ...(toArray(args["filter.platform"])?.length && {
+      "filter[platform]": toArray(args["filter.platform"])!,
     }),
-    ...(toArray(args["filter[version]"])?.length && {
-      "filter[version]": toArray(args["filter[version]"])!,
+    ...(toArray(args["filter.version"])?.length && {
+      "filter[version]": toArray(args["filter.version"])!,
     }),
-    ...(toArray(args["filter[id]"])?.length && {
-      "filter[id]": toArray(args["filter[id]"])!,
+    ...(toArray(args["filter.id"])?.length && {
+      "filter[id]": toArray(args["filter.id"])!,
     }),
   };
   const result =

--- a/src/tools/list-profiles.ts
+++ b/src/tools/list-profiles.ts
@@ -33,19 +33,19 @@ export const schema = {
     .max(200)
     .default(100)
     .describe("Maximum number of profiles to return (default 100, max 200)"),
-  "filter[name]": z
+  "filter.name": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by profile name(s)"),
-  "filter[profileType]": z
+  "filter.profileType": z
     .union([profileTypeEnum, z.array(profileTypeEnum)])
     .optional()
     .describe("Filter by profile type(s)"),
-  "filter[profileState]": z
+  "filter.profileState": z
     .union([profileStateEnum, z.array(profileStateEnum)])
     .optional()
     .describe("Filter by profile state(s)"),
-  "filter[id]": z
+  "filter.id": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by profile ID(s)"),
@@ -68,17 +68,17 @@ export default async function listProfilesTool(
   const client = getClient();
   const query: NonNullable<ProfilesGetCollectionData["query"]> = {
     limit: args.limit,
-    ...(toArray(args["filter[name]"])?.length && {
-      "filter[name]": toArray(args["filter[name]"])!,
+    ...(toArray(args["filter.name"])?.length && {
+      "filter[name]": toArray(args["filter.name"])!,
     }),
-    ...(toArray(args["filter[profileType]"])?.length && {
-      "filter[profileType]": toArray(args["filter[profileType]"])!,
+    ...(toArray(args["filter.profileType"])?.length && {
+      "filter[profileType]": toArray(args["filter.profileType"])!,
     }),
-    ...(toArray(args["filter[profileState]"])?.length && {
-      "filter[profileState]": toArray(args["filter[profileState]"])!,
+    ...(toArray(args["filter.profileState"])?.length && {
+      "filter[profileState]": toArray(args["filter.profileState"])!,
     }),
-    ...(toArray(args["filter[id]"])?.length && {
-      "filter[id]": toArray(args["filter[id]"])!,
+    ...(toArray(args["filter.id"])?.length && {
+      "filter[id]": toArray(args["filter.id"])!,
     }),
   };
   const result = await client.api.Profiles.profilesGetCollection({ query });

--- a/src/tools/list-review-submissions.ts
+++ b/src/tools/list-review-submissions.ts
@@ -20,7 +20,7 @@ const stateEnum = z.enum([
 ]);
 
 export const schema = {
-  "filter[app]": z
+  "filter.app": z
     .union([z.string(), z.array(z.string())])
     .describe("App ID(s) (required). Submission history for this app."),
   limit: z
@@ -31,11 +31,11 @@ export const schema = {
     .describe(
       'Maximum number of review submissions to return (default 100, max 200)'
     ),
-  "filter[platform]": z
+  "filter.platform": z
     .union([platformEnum, z.array(platformEnum)])
     .optional()
     .describe("Filter by platform(s)"),
-  "filter[state]": z
+  "filter.state": z
     .union([stateEnum, z.array(stateEnum)])
     .optional()
     .describe("Filter by submission state(s)"),
@@ -66,13 +66,13 @@ export default async function listReviewSubmissionsTool(
 ) {
   const client = getClient();
   const query: NonNullable<ReviewSubmissionsGetCollectionData["query"]> = {
-    "filter[app]": toArray(args["filter[app]"])!,
+    "filter[app]": toArray(args["filter.app"])!,
     limit: args.limit,
-    ...(toArray(args["filter[platform]"])?.length && {
-      "filter[platform]": toArray(args["filter[platform]"])!,
+    ...(toArray(args["filter.platform"])?.length && {
+      "filter[platform]": toArray(args["filter.platform"])!,
     }),
-    ...(toArray(args["filter[state]"])?.length && {
-      "filter[state]": toArray(args["filter[state]"])!,
+    ...(toArray(args["filter.state"])?.length && {
+      "filter[state]": toArray(args["filter.state"])!,
     }),
   };
   const result =

--- a/src/tools/list-subscription-group-subscriptions.ts
+++ b/src/tools/list-subscription-group-subscriptions.ts
@@ -33,15 +33,15 @@ export const schema = {
     .max(200)
     .default(50)
     .describe("Maximum number of subscriptions to return (default 50, max 200)"),
-  "filter[productId]": z
+  "filter.productId": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by product ID(s), e.g. premium_monthly_v2"),
-  "filter[name]": z
+  "filter.name": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by subscription name(s)"),
-  "filter[state]": z
+  "filter.state": z
     .union([stateEnum, z.array(stateEnum)])
     .optional()
     .describe("Filter by state (e.g. APPROVED)"),
@@ -72,14 +72,14 @@ export default async function listSubscriptionGroupSubscriptionsTool(
     SubscriptionGroupsSubscriptionsGetToManyRelatedData["query"]
   > = {
     limit: args.limit,
-    ...(toArray(args["filter[productId]"])?.length && {
-      "filter[productId]": toArray(args["filter[productId]"])!,
+    ...(toArray(args["filter.productId"])?.length && {
+      "filter[productId]": toArray(args["filter.productId"])!,
     }),
-    ...(toArray(args["filter[name]"])?.length && {
-      "filter[name]": toArray(args["filter[name]"])!,
+    ...(toArray(args["filter.name"])?.length && {
+      "filter[name]": toArray(args["filter.name"])!,
     }),
-    ...(toArray(args["filter[state]"])?.length && {
-      "filter[state]": toArray(args["filter[state]"])!,
+    ...(toArray(args["filter.state"])?.length && {
+      "filter[state]": toArray(args["filter.state"])!,
     }),
     ...(args.sort && { sort: [args.sort] }),
   };

--- a/src/tools/list-subscription-groups.ts
+++ b/src/tools/list-subscription-groups.ts
@@ -18,7 +18,7 @@ export const schema = {
     .max(200)
     .default(50)
     .describe("Maximum number of groups to return (default 50, max 200)"),
-  "filter[referenceName]": z
+  "filter.referenceName": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by reference name(s), e.g. Premium"),
@@ -45,8 +45,8 @@ export default async function listSubscriptionGroupsTool(
     AppsSubscriptionGroupsGetToManyRelatedData["query"]
   > = {
     limit: args.limit,
-    ...(toArray(args["filter[referenceName]"])?.length && {
-      "filter[referenceName]": toArray(args["filter[referenceName]"])!,
+    ...(toArray(args["filter.referenceName"])?.length && {
+      "filter[referenceName]": toArray(args["filter.referenceName"])!,
     }),
   };
   const result =

--- a/src/tools/list-subscription-price-points.ts
+++ b/src/tools/list-subscription-price-points.ts
@@ -14,7 +14,7 @@ export const schema = {
     .describe(
       "Subscription ID (from create-subscription or list-subscription-group-subscriptions)"
     ),
-  "filter[territory]": z
+  "filter.territory": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe(
@@ -49,8 +49,8 @@ export default async function listSubscriptionPricePointsTool(
     SubscriptionsPricePointsGetToManyRelatedData["query"]
   > = {
     limit: args.limit,
-    ...(toArray(args["filter[territory]"])?.length && {
-      "filter[territory]": toArray(args["filter[territory]"])!,
+    ...(toArray(args["filter.territory"])?.length && {
+      "filter[territory]": toArray(args["filter.territory"])!,
     }),
   };
   const result =

--- a/src/tools/list-user-invitations.ts
+++ b/src/tools/list-user-invitations.ts
@@ -33,15 +33,15 @@ export const schema = {
     .describe(
       "Maximum number of user invitations to return (default 100, max 200)"
     ),
-  "filter[email]": z
+  "filter.email": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by invite email(s)"),
-  "filter[roles]": z
+  "filter.roles": z
     .union([roleEnum, z.array(roleEnum)])
     .optional()
     .describe("Filter by role(s)"),
-  "filter[visibleApps]": z
+  "filter.visibleApps": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by visible app ID(s)"),
@@ -64,14 +64,14 @@ export default async function listUserInvitationsTool(
   const client = getClient();
   const query: NonNullable<UserInvitationsGetCollectionData["query"]> = {
     limit: args.limit,
-    ...(toArray(args["filter[email]"])?.length && {
-      "filter[email]": toArray(args["filter[email]"])!,
+    ...(toArray(args["filter.email"])?.length && {
+      "filter[email]": toArray(args["filter.email"])!,
     }),
-    ...(toArray(args["filter[roles]"])?.length && {
-      "filter[roles]": toArray(args["filter[roles]"])!,
+    ...(toArray(args["filter.roles"])?.length && {
+      "filter[roles]": toArray(args["filter.roles"])!,
     }),
-    ...(toArray(args["filter[visibleApps]"])?.length && {
-      "filter[visibleApps]": toArray(args["filter[visibleApps]"])!,
+    ...(toArray(args["filter.visibleApps"])?.length && {
+      "filter[visibleApps]": toArray(args["filter.visibleApps"])!,
     }),
   };
   const result =

--- a/src/tools/list-users.ts
+++ b/src/tools/list-users.ts
@@ -31,15 +31,15 @@ export const schema = {
     .max(200)
     .default(100)
     .describe("Maximum number of users to return (default 100, max 200)"),
-  "filter[username]": z
+  "filter.username": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by username(s)"),
-  "filter[roles]": z
+  "filter.roles": z
     .union([roleEnum, z.array(roleEnum)])
     .optional()
     .describe("Filter by role(s)"),
-  "filter[visibleApps]": z
+  "filter.visibleApps": z
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe("Filter by visible app ID(s)"),
@@ -60,14 +60,14 @@ export default async function listUsersTool(args: InferSchema<typeof schema>) {
   const client = getClient();
   const query: NonNullable<UsersGetCollectionData["query"]> = {
     limit: args.limit,
-    ...(toArray(args["filter[username]"])?.length && {
-      "filter[username]": toArray(args["filter[username]"])!,
+    ...(toArray(args["filter.username"])?.length && {
+      "filter[username]": toArray(args["filter.username"])!,
     }),
-    ...(toArray(args["filter[roles]"])?.length && {
-      "filter[roles]": toArray(args["filter[roles]"])!,
+    ...(toArray(args["filter.roles"])?.length && {
+      "filter[roles]": toArray(args["filter.roles"])!,
     }),
-    ...(toArray(args["filter[visibleApps]"])?.length && {
-      "filter[visibleApps]": toArray(args["filter[visibleApps]"])!,
+    ...(toArray(args["filter.visibleApps"])?.length && {
+      "filter[visibleApps]": toArray(args["filter.visibleApps"])!,
     }),
   };
   const result = await client.api.Users.usersGetCollection({ query });


### PR DESCRIPTION
## Problem

Tool schemas in `list-*` tools use property keys with square brackets (`filter[id]`, `filter[name]`, `exists[parent]`, etc.). The Anthropic API rejects these — property keys in `inputSchema.properties` must match `^[a-zA-Z0-9_.-]{1,64}$`.

Calling these tools from Claude Code / Claude API fails with:

```
API Error: 400 {"type":"error","error":{"type":"invalid_request_error",
"message":"tools.14.custom.input_schema.properties:
Property keys should match pattern '^[a-zA-Z0-9_.-]{1,64}$'"}}
```

Scope: **28 `list-*` tools**, ~49 unique bracket keys.

Fixes #1, #2.

## Fix

Rename schema-facing keys to dot notation (valid per the Anthropic pattern) while keeping the outgoing Apple API query keys unchanged — the App Store Connect API uses bracket-style query parameters and the `@rage-against-the-pixel/app-store-connect-api` types require them.

Per tool file:

| Location | Before | After |
|---|---|---|
| `schema` export (exposed to MCP client) | `"filter[id]": z...` | `"filter.id": z...` |
| `args[...]` reads in handler | `args["filter[id]"]` | `args["filter.id"]` |
| `query` object sent to Apple | `"filter[id]": toArray(...)` | **unchanged** |

Example (`list-app-categories.ts`):

```diff
 export const schema = {
-  "filter[platforms]": z.union([...]).optional(),
-  "exists[parent]":    z.boolean().optional(),
+  "filter.platforms": z.union([...]).optional(),
+  "exists.parent":    z.boolean().optional(),
 };

 const query: NonNullable<AppCategoriesGetCollectionData["query"]> = {
-  ...(toArray(args["filter[platforms]"])?.length && {
-    "filter[platforms]": toArray(args["filter[platforms]"])!,
+  ...(toArray(args["filter.platforms"])?.length && {
+    "filter[platforms]": toArray(args["filter.platforms"])!,   // Apple API key kept
   }),
 };
```

## Verification

- `npx tsc --noEmit` — 0 errors (the `@rage-against-the-pixel/app-store-connect-api` query types still expect the bracket keys, which is why `tsc` would immediately catch any accidental rename on the outgoing side).
- `npm run build` — clean, 68 tools registered.
- `download-sales-report` / `download-finance-report` were already clean (they never exposed bracket keys in their schema, only in the outgoing query) — no changes needed there.

## No behavior change for Apple API

Every key actually sent to App Store Connect is byte-for-byte identical to before. This PR only changes the names the LLM/MCP client sees and passes back in — those names are then translated to Apple's bracket form inside each handler.